### PR TITLE
Support building for Node v12

### DIFF
--- a/src/statvfs.cpp
+++ b/src/statvfs.cpp
@@ -41,11 +41,14 @@ static Nan::Persistent<String> namemax_sym;
 	if (ARGS.Length() == 0)					\
 		RETURN_ARGS_EXCEPTION("missing arguments");
 
-#define REQUIRE_STRING_ARG(ARGS, I, VAR)				  \
-	REQUIRE_ARGS(ARGS);										   \
-	if (ARGS.Length() <= (I) || !ARGS[I]->IsString())		\
+#define REQUIRE_STRING_ARG(ARGS, I, VAR)				\
+	REQUIRE_ARGS(ARGS);						\
+	if (ARGS.Length() <= (I))					\
 		RETURN_ARGS_EXCEPTION("argument " #I " must be a String"); \
-	Nan::Utf8String VAR(ARGS[I]->ToString());
+	Nan::MaybeLocal<v8::String> _ ## VAR(Nan::To<v8::String>(ARGS[I])); \
+	if (_ ## VAR.IsEmpty())					\
+		RETURN_ARGS_EXCEPTION("argument " #I " must be a String"); \
+	Nan::Utf8String VAR(_ ## VAR.ToLocalChecked());
 
 #define REQUIRE_FUNCTION_ARG(ARGS, I, VAR)							  \
 	REQUIRE_ARGS(ARGS);						\


### PR DESCRIPTION
Currently this package does not build on Node v12, due to the following error:
```
../src/statvfs.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE _statvfs_entry(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/statvfs.cpp:48:40: error: no matching function for call to ‘v8::Value::ToString()’
  Nan::Utf8String VAR(ARGS[I]->ToString());
```

I am doing exactly the same fix as in https://github.com/joyent/node-bunyan-syslog/commit/1261cf78d2bf233110c7c98725d180c1c5d3839c, which does allow node-statvfs to be successfully built on Node v12.